### PR TITLE
Updated the python runtime to 3.9

### DIFF
--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -858,7 +858,7 @@ Resources:
             - - !Ref QSS3KeyPrefix
               - "functions/packages/LeaderElection/lambda.zip"
       Handler: "lambda_function.lambda_handler"
-      Runtime: python3.6
+      Runtime: python3.9
       Environment:
         Variables:
           LeaderElectedSSM: !Ref VaultLeaderElectedSSM
@@ -922,7 +922,7 @@ Resources:
           LeaderSSM: !Ref VaultLeaderElectedSSM
           ClusterMembersSSM: !Ref VaultClusterMembersSSM
           AutoScalingGroup: !Sub "VaultServerAutoScalingGroup-${AWS::StackName}"
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 300
       Role: !GetAtt ClusterBootstrapLambdaExecutionRole.Arn
   ClusterBootstrapLambdaExecutionRole:


### PR DESCRIPTION
The python runtime version 3.6 is not supported by AWS anymore and the cloud formation template results in a failure due to unsupported runtime version. The AWS recommended runtime is 3.9.